### PR TITLE
 Prepare database migration support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<java.version>17</java.version>
 		<org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
 		<spring-cloud.version>2022.0.1</spring-cloud.version>
+		<liquibase.version>4.19.0</liquibase.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -47,6 +48,11 @@
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
 			<version>${org.mapstruct.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+			<version>${liquibase.version}</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,24 @@
+spring.main.banner-mode=off
+spring.jpa.hibernate.ddl-auto=none
+spring.sql.init.mode=always
+
+spring.sql.init.platform=postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+
+server.servlet.context-path=/api/v1
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.jpa.generate-ddl=true
+
+overworld.url=http://localhost/overworld/api/v1
+keycloak.issuer=http://localhost/keycloak/realms/Gamify-IT
+keycloak.url=http://localhost/keycloak/realms/Gamify-IT
+
+springdoc.swagger-ui.path=/swagger-ui
+springdoc.swagger-ui.disable-swagger-default-url=true
+server.error.include-message=always
+
+spring.liquibase.change-log=classpath:db/changelog-root.xml
+
 

--- a/src/main/resources/db/changelog-root.xml
+++ b/src/main/resources/db/changelog-root.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd
+    http://www.liquibase.org/xml/ns/pro
+    http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd">
+  <!-- Automatically queries all files in this directory in lexical order -->
+  <includeAll path="db/changelog/"/>
+</databaseChangeLog>


### PR DESCRIPTION
In the future, any PR that changes stored data must also adapt the corresponding changelog under `src/main/resources/db/changelog/changelog-<version>.sql`.
New versions should also use a new changelog instead of appending to an old one.
For details on how to keep the changelog up to date, consult the docs.

The initial changelog was not generated as there is no data yet.
Once it is present, it can be added simply by calling

```sh
liquibase generateChangeLog --username $DB_USER --password $DB_PASSWORD --url jdbc:postgresql://localhost:5432/postgres --changeLogFile src/main/resources/db/changelog/changelog-1.0.sql
```

Part of Gamify-IT/issues#439.